### PR TITLE
Update Sidebar.tsx

### DIFF
--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -38,10 +38,11 @@ export const Sidebar: React.FunctionComponent = () => {
       </a>
       <ul className="text-sm mt-2">
         {messages.map((message, index) => (
-          <li key={`menu-message-list-${message.name() ?? index}`}>
+           <li key={`menu-message-list-${message.name() ?? index}`}>
+          {/*  fixed the message.name() to message.id() to fix undifined name  */}
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
-              href={`#message-${message.name()}`}
+              href={`#message-${message.id()}`}
               onClick={() => setShowSidebar(false)}
             >
               <div className="break-all inline-block">{message.id()}</div>


### PR DESCRIPTION
fixed this issue #1109

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The anchor link for a message in the sidebar does not work as expected when message.name() and message.id() differ.

**Expected result**
Clicking on a message in the sidebar should set the correct hash in the URL and scroll the message into view.

Actual result
The anchor link only works if message.name() and message.id() are identical.
If message.name() is not provided, the hash becomes #message-undefined.

**before**
<img width="758" alt="image" src="https://github.com/user-attachments/assets/a7150c4b-275e-4d51-b5e2-ec40ad0a9119">

**after**
<img width="722" alt="image" src="https://github.com/user-attachments/assets/2199e35f-5ffe-46ac-b757-fdee26a4c95d">

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the anchor link in the sidebar did not work correctly when message.name() and message.id() differed by changing the href attribute to use message.id().